### PR TITLE
remove unused imports from generated code

### DIFF
--- a/processor/src/main/java/org/mapstruct/tools/gem/processor/GemInfo.java
+++ b/processor/src/main/java/org/mapstruct/tools/gem/processor/GemInfo.java
@@ -63,6 +63,7 @@ public class GemInfo {
             .map( GemValueInfo::getValueType )
             .filter( this::isNotJavaLang )
             .filter( this::isNotSamePackage )
+            .filter( this::isNotTypeMirror )
             .map( GemValueType::getFqn )
             .collect( Collectors.toSet() );
     }
@@ -85,5 +86,9 @@ public class GemInfo {
 
     private boolean isNotJavaLang( GemValueType valueType ) {
         return !"java.lang".equals( valueType.getPacakage() );
+    }
+
+    private boolean isNotTypeMirror( GemValueType valueType ) {
+        return !"javax.lang.model.type.TypeMirror".equals( valueType.getFqn() );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/tools/gem/processor/Gem.ftl
+++ b/processor/src/main/resources/org/mapstruct/tools/gem/processor/Gem.ftl
@@ -8,23 +8,30 @@
 <#-- @ftlvariable name="gemInfo" type="org.mapstruct.tools.gem.processor.GemInfo" -->
 package ${gemInfo.gemPackageName};
 
-import java.util.ArrayList;
+<#assign hasGemInfoValues = gemInfo.gemValueInfos?size &gt; 0>
+<#if hasGemInfoValues>
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+</#if>
 import javax.lang.model.element.AnnotationMirror;
+<#if hasGemInfoValues>
 import javax.lang.model.element.AnnotationValue;
+</#if>
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
+<#if hasGemInfoValues>
 import javax.lang.model.element.ExecutableElement;
+</#if>
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
+<#if hasGemInfoValues>
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.AbstractAnnotationValueVisitor8;
 import javax.lang.model.util.ElementFilter;
+</#if>
 import org.mapstruct.tools.gem.Gem;
+<#if hasGemInfoValues>
 import org.mapstruct.tools.gem.GemValue;
+</#if>
 
 <#list gemInfo.imports as importItem>
 import ${importItem};
@@ -35,7 +42,7 @@ public class ${gemInfo.gemName} implements Gem {
 <#list gemInfo.gemValueInfos as gemValueInfo>
     private final GemValue<${gemValueInfo.valueType.name}> ${gemValueInfo.name};
 </#list>
-<#if (gemInfo.gemValueInfos?size > 0) >
+<#if hasGemInfoValues>
     private final boolean isValid;
 </#if>
     private final AnnotationMirror mirror;
@@ -68,10 +75,10 @@ public class ${gemInfo.gemName} implements Gem {
 
     @Override
     public boolean isValid( ) {
-    <#if gemInfo.gemValueInfos?size == 0>
-        return true;
-    <#else>
+    <#if hasGemInfoValues>
         return isValid;
+    <#else>
+        return true;
     </#if>
     }
 
@@ -97,7 +104,7 @@ public class ${gemInfo.gemName} implements Gem {
         if ( mirror == null || builder == null ) {
             return null;
         }
-        <#if gemInfo.gemValueInfos?size != 0>
+        <#if hasGemInfoValues>
 
         // fetch defaults from all defined values in the annotation type
         List<ExecutableElement> enclosed = ElementFilter.methodsIn( mirror.getAnnotationType().asElement().getEnclosedElements() );

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/BuilderGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/BuilderGem.java
@@ -1,22 +1,9 @@
 package org.mapstruct.tools.gem.processor;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.AbstractAnnotationValueVisitor8;
-import javax.lang.model.util.ElementFilter;
 import org.mapstruct.tools.gem.Gem;
-import org.mapstruct.tools.gem.GemValue;
 
 
 public class BuilderGem implements Gem {

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/CustomBuilderGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/CustomBuilderGem.java
@@ -1,22 +1,9 @@
 package org.mapstruct.tools.gem.processor;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.AbstractAnnotationValueVisitor8;
-import javax.lang.model.util.ElementFilter;
 import org.mapstruct.tools.gem.Gem;
-import org.mapstruct.tools.gem.GemValue;
 
 
 public class CustomBuilderGem implements Gem {

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SomeAnnotationGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SomeAnnotationGem.java
@@ -1,6 +1,5 @@
 package org.mapstruct.tools.gem.processor;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -8,17 +7,13 @@ import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.AbstractAnnotationValueVisitor8;
 import javax.lang.model.util.ElementFilter;
 import org.mapstruct.tools.gem.Gem;
 import org.mapstruct.tools.gem.GemValue;
 
-import javax.lang.model.type.TypeMirror;
 
 public class SomeAnnotationGem implements Gem {
 

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SomeAnnotationsGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SomeAnnotationsGem.java
@@ -1,6 +1,5 @@
 package org.mapstruct.tools.gem.processor;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -8,12 +7,9 @@ import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.AbstractAnnotationValueVisitor8;
 import javax.lang.model.util.ElementFilter;
 import org.mapstruct.tools.gem.Gem;
 import org.mapstruct.tools.gem.GemValue;

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SomeArrayAnnotationGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SomeArrayAnnotationGem.java
@@ -1,6 +1,5 @@
 package org.mapstruct.tools.gem.processor;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -8,17 +7,13 @@ import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.AbstractAnnotationValueVisitor8;
 import javax.lang.model.util.ElementFilter;
 import org.mapstruct.tools.gem.Gem;
 import org.mapstruct.tools.gem.GemValue;
 
-import javax.lang.model.type.TypeMirror;
 
 public class SomeArrayAnnotationGem implements Gem {
 


### PR DESCRIPTION
This PR removes unused imports and simplifies conditional imports in the template.
**Changes**

- Removed the following unused imports:
  - `java.util.ArrayList;`
  - `javax.lang.model.element.ElementKind`
  - `javax.lang.model.element.VariableElement`
  - `javax.lang.model.util.AbstractAnnotationValueVisitor8`
- he following imports are only required when `gemValueInfos` contains values. Instead of always including them, they are now conditionally added via an `if` statement in the FTL template:
  - `java.util.HashMap`
  - `java.util.List`
  - `java.util.Map`
  - `javax.lang.model.element.AnnotationValue`
  - `javax.lang.model.element.ExecutableElement`
  - `javax.lang.model.type.TypeMirror`
  - `javax.lang.model.util.ElementFilter;`
  - `org.mapstruct.tools.gem.GemValue`
 - `javax.lang.model.type.TypeMirror` is already imported elsewhere and has therefore been excluded from the manual import list.