### PR TITLE
#10 allow custom implementation names

### DIFF
--- a/api/src/main/java/org/mapstruct/tools/gem/GemDefinition.java
+++ b/api/src/main/java/org/mapstruct/tools/gem/GemDefinition.java
@@ -30,9 +30,9 @@ public @interface GemDefinition {
      * Specifies the name of the implementation class. The {@code <CLASS_NAME>} will be replaced by the
      * interface/abstract class name.
      * <p>
-     * Defaults to postfixing the name with {@code Gem}: {@code <CLASS_NAME>Impl}
+     * Defaults to postfixing the name with {@code Gem}: {@code <CLASS_NAME>Gem}
      *
      * @return The implementation name.
      */
-    String implementationName() default "<CLASS_NAME>";
+    String implementationName() default "<CLASS_NAME>Gem";
 }

--- a/api/src/main/java/org/mapstruct/tools/gem/GemDefinition.java
+++ b/api/src/main/java/org/mapstruct/tools/gem/GemDefinition.java
@@ -25,4 +25,14 @@ public @interface GemDefinition {
      * @return the annotation for which a Gem should be generated
      */
     Class<?> value();
+
+    /**
+     * Specifies the name of the implementation class. The {@code <CLASS_NAME>} will be replaced by the
+     * interface/abstract class name.
+     * <p>
+     * Defaults to postfixing the name with {@code Gem}: {@code <CLASS_NAME>Impl}
+     *
+     * @return The implementation name.
+     */
+    String implementationName() default "<CLASS_NAME>";
 }

--- a/processor/src/main/java/org/mapstruct/tools/gem/processor/GemInfo.java
+++ b/processor/src/main/java/org/mapstruct/tools/gem/processor/GemInfo.java
@@ -26,10 +26,10 @@ public class GemInfo {
     private final List<GemValueInfo> gemValueInfos;
     private final Element[] originatingElements;
 
-    public GemInfo(String gemPackageName, String annotationName, String annotationFqn,
+    public GemInfo(String gemPackageName, String gemName, String annotationName, String annotationFqn,
         List<GemValueInfo> gemValueInfos, Element... originatingElements) {
         this.gemPackageName = gemPackageName;
-        this.gemName = annotationName + "Gem";
+        this.gemName = gemName;
         this.annotationName = annotationName;
         this.annotationFqn = annotationFqn;
         this.gemValueInfos = gemValueInfos;

--- a/processor/src/main/java/org/mapstruct/tools/gem/processor/GemProcessor.java
+++ b/processor/src/main/java/org/mapstruct/tools/gem/processor/GemProcessor.java
@@ -95,8 +95,9 @@ public class GemProcessor extends AbstractProcessor {
 
         // create gem info
         DeclaredType gemDeclaredType = util.getAnnotationValue( gemDefinitionMirror, "value", DeclaredType.class );
+        String annotationName = util.getSimpleName( gemDeclaredType );
+        String gemName = getGemName( gemDefinitionMirror, annotationName );
         PackageElement pkg = processingEnv.getElementUtils().getPackageOf( definingElement );
-        String gemName = util.getSimpleName( gemDeclaredType );
         String gemFqn = util.getFullyQualifiedName( gemDeclaredType );
         String gemPackage = pkg.getQualifiedName().toString();
 
@@ -108,12 +109,21 @@ public class GemProcessor extends AbstractProcessor {
         GemInfo gemInfo = new GemInfo(
             gemPackage,
             gemName,
+            annotationName,
             gemFqn,
             gemValueInfos,
             definingElement,
             gemDeclaredType.asElement()
         );
         gemInfos.add( gemInfo );
+    }
+
+    private String getGemName(AnnotationMirror gemDefinitionMirror, String annotationName) {
+        String implementationName = util.getAnnotationValue( gemDefinitionMirror, "implementationName", String.class );
+        if ( implementationName != null ) {
+            return implementationName.replace( "<CLASS_NAME>", annotationName );
+        }
+        return annotationName + "Gem";
     }
 
     private void postProcessGemInfo() {

--- a/processor/src/test/java/org/mapstruct/tools/gem/processor/ProcessorTest.java
+++ b/processor/src/test/java/org/mapstruct/tools/gem/processor/ProcessorTest.java
@@ -42,6 +42,7 @@ class ProcessorTest {
         );
         File generatedDir = compile( new GemProcessor(), src );
         assertGeneratedFileContent( "BuilderGem", generatedDir );
+        assertGeneratedFileContent( "CustomBuilderGem", generatedDir );
         assertGeneratedFileContent( "SomeAnnotationGem", generatedDir );
         assertGeneratedFileContent( "SomeAnnotationsGem", generatedDir );
         assertGeneratedFileContent( "SomeArrayAnnotationGem", generatedDir );
@@ -145,6 +146,7 @@ class ProcessorTest {
             "@GemDefinition(value = SomeAnnotations.class)\n" +
             "@GemDefinition(value = SomeArrayAnnotation.class)\n" +
             "@GemDefinition(value = Builder.class)\n" +
+            "@GemDefinition(value = Builder.class, implementationName = \"Custom<CLASS_NAME>Gem\")\n" +
             "public class GemGenerator {\n" +
             "}";
     }

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/CustomBuilderGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/CustomBuilderGem.java
@@ -1,0 +1,104 @@
+package org.mapstruct.tools.gem.processor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.AbstractAnnotationValueVisitor8;
+import javax.lang.model.util.ElementFilter;
+import org.mapstruct.tools.gem.Gem;
+import org.mapstruct.tools.gem.GemValue;
+
+
+public class CustomBuilderGem implements Gem {
+
+    private final AnnotationMirror mirror;
+
+    private CustomBuilderGem( BuilderImpl builder ) {
+        mirror = builder.mirror;
+    }
+
+    @Override
+    public AnnotationMirror mirror( ) {
+        return mirror;
+    }
+
+    @Override
+    public boolean isValid( ) {
+        return true;
+    }
+
+    public static CustomBuilderGem  instanceOn(Element element) {
+        return build( element, new BuilderImpl() );
+    }
+
+    public static CustomBuilderGem instanceOn(AnnotationMirror mirror ) {
+        return build( mirror, new BuilderImpl() );
+    }
+
+    public static  <T> T  build(Element element, Builder_<T> builder) {
+        AnnotationMirror mirror = element.getAnnotationMirrors().stream()
+            .filter( a ->  "org.mapstruct.tools.gem.test.Builder".contentEquals( ( ( TypeElement )a.getAnnotationType().asElement() ).getQualifiedName() ) )
+            .findAny()
+            .orElse( null );
+        return build( mirror, builder );
+    }
+
+    public static <T> T build(AnnotationMirror mirror, Builder_<T> builder ) {
+
+        // return fast
+        if ( mirror == null || builder == null ) {
+            return null;
+        }
+        builder.setMirror( mirror );
+        return builder.build();
+    }
+
+    /**
+     * A builder that can be implemented by the user to define custom logic e.g. in the
+     * build method, prior to creating the annotation gem.
+     */
+    public interface Builder_<T> {
+
+        /**
+         * Sets the annotation mirror
+         *
+         * @param mirror the mirror which this gem represents
+         *
+         * @return the {@link Builder_} for this gem, representing {@link CustomBuilderGem}
+         */
+          Builder_<T> setMirror( AnnotationMirror mirror );
+
+        /**
+         * The build method can be overriden in a custom custom implementation, which allows
+         * the user to define his own custom validation on the annotation.
+         *
+         * @return the representation of the annotation
+         */
+        T build();
+    }
+
+    private static class BuilderImpl implements Builder_<CustomBuilderGem> {
+
+        private AnnotationMirror mirror;
+
+        public Builder_<CustomBuilderGem> setMirror( AnnotationMirror mirror ) {
+            this.mirror = mirror;
+            return this;
+        }
+
+        public CustomBuilderGem build() {
+            return new CustomBuilderGem( this );
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #10 by allowing custom implementation names.
The implementation is inspired by `@Mapper` from MapStruct.