### PR TITLE
add support for single GemDefinition annotation

### DIFF
--- a/processor/src/main/java/org/mapstruct/tools/gem/processor/GemProcessor.java
+++ b/processor/src/main/java/org/mapstruct/tools/gem/processor/GemProcessor.java
@@ -39,7 +39,7 @@ import freemarker.template.Version;
 /**
  * @author sjaakd
  */
-@SupportedAnnotationTypes( "org.mapstruct.tools.gem.GemDefinitions" )
+@SupportedAnnotationTypes( {"org.mapstruct.tools.gem.GemDefinitions", "org.mapstruct.tools.gem.GemDefinition"} )
 public class GemProcessor extends AbstractProcessor {
 
     private Util util;
@@ -55,24 +55,28 @@ public class GemProcessor extends AbstractProcessor {
         try {
             util = new Util( processingEnv.getTypeUtils(), processingEnv.getElementUtils() );
             for ( TypeElement annotationType : annotationTypes ) {
-
+                String annotationName = annotationType.getQualifiedName().toString();
                 for ( Element definingElement : roundEnv.getElementsAnnotatedWith( annotationType ) ) {
 
                     // get an annotation mirror on @GemDefinitions
                     AnnotationMirror gemDefinitionsMirror = definingElement
                         .getAnnotationMirrors()
                         .stream()
-                        .filter( t -> util.isSame( t.getAnnotationType(), "org.mapstruct.tools.gem.GemDefinitions" ) )
+                        .filter( t -> util.isSame( t.getAnnotationType(), annotationName ) )
                         .findFirst()
                         .orElseThrow( IllegalStateException::new );
-
-                    // get annotation mirrors on each @GemDefinitions#value
-                    List<AnnotationMirror> gemDefinitionMirrors = util.getAnnotationValue(
-                        gemDefinitionsMirror,
-                        "value",
-                        List.class
-                    );
-                    gemDefinitionMirrors.forEach( m -> addGemInfo( m, definingElement ) );
+                    if ( annotationName.endsWith( "s" ) ) {
+                        // get annotation mirrors on each @GemDefinitions#value
+                        List<AnnotationMirror> gemDefinitionMirrors = util.getAnnotationValue(
+                                gemDefinitionsMirror,
+                                "value",
+                                List.class
+                        );
+                        gemDefinitionMirrors.forEach( m -> addGemInfo( m, definingElement ) );
+                    }
+                    else {
+                        addGemInfo( gemDefinitionsMirror, definingElement );
+                    }
                 }
             }
             postProcessGemInfo();

--- a/processor/src/test/java/org/mapstruct/tools/gem/processor/ProcessorTest.java
+++ b/processor/src/test/java/org/mapstruct/tools/gem/processor/ProcessorTest.java
@@ -40,10 +40,31 @@ class ProcessorTest {
             "org.mapstruct.annotations.processor.GemGenerator",
             getSource()
         );
-        compile( new GemProcessor(), src );
+        File generatedDir = compile( new GemProcessor(), src );
+        assertGeneratedFileContent( "BuilderGem", generatedDir );
+        assertGeneratedFileContent( "SomeAnnotationGem", generatedDir );
+        assertGeneratedFileContent( "SomeAnnotationsGem", generatedDir );
+        assertGeneratedFileContent( "SomeArrayAnnotationGem", generatedDir );
     }
 
-    private void compile(Processor processor, JavaFileObject... compilationUnits) throws IOException {
+    @Test
+    void singleAnnotation() throws IOException {
+        StringJavaFileObject src = new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.GemGenerator",
+                "package org.mapstruct.tools.gem.processor;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.GemDefinition;\n" +
+                        "import org.mapstruct.tools.gem.test.Builder;\n" +
+                        "\n" +
+                        "@GemDefinition(value = Builder.class)\n" +
+                        "public class GemGenerator {\n" +
+                        "}"
+        );
+        File generatedDir = compile( new GemProcessor(), src );
+        assertGeneratedFileContent( "BuilderGem", generatedDir );
+    }
+
+    private File compile(Processor processor, JavaFileObject... compilationUnits) throws IOException {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
@@ -71,12 +92,7 @@ class ProcessorTest {
             System.err.println( diagnostic );
         }
         assertThat( success ).isTrue();
-
-
-        assertGeneratedFileContent( "BuilderGem", generatedDir );
-        assertGeneratedFileContent( "SomeAnnotationGem", generatedDir );
-        assertGeneratedFileContent( "SomeAnnotationsGem", generatedDir );
-        assertGeneratedFileContent( "SomeArrayAnnotationGem", generatedDir );
+        return generatedDir;
     }
 
     protected void assertGeneratedFileContent(String gemName, File generatedDir) {


### PR DESCRIPTION
The current implementation won't recognize a single ` @GemDefinition` annotation.