### PR TITLE
introduce gem for enums

### DIFF
--- a/api/src/main/java/org/mapstruct/tools/gem/GemValue.java
+++ b/api/src/main/java/org/mapstruct/tools/gem/GemValue.java
@@ -48,12 +48,33 @@ public class GemValue<T> {
         return new GemValue<>( value, defaultValue, annotationValue );
     }
 
+    public static <E extends Enum<E>> GemValue<E> createEnum(AnnotationValue annotationValue,
+                                                             AnnotationValue annotationDefaultValue,
+                                                             Class<E> enumClass) {
+        ValueAnnotationValueVisitor<VariableElement, E> visitor = new ValueAnnotationValueVisitor<>(
+                variableElement -> Enum.valueOf( enumClass, variableElement.getSimpleName().toString() ) );
+        E value = visit( annotationValue, visitor, VariableElement.class );
+        E defaultValue = visit( annotationDefaultValue, visitor, VariableElement.class );
+        return new GemValue<>( value, defaultValue, annotationValue );
+    }
+
     public static GemValue<List<String>> createEnumArray(AnnotationValue annotationValue,
         AnnotationValue annotationDefaultValue) {
         ValueAnnotationValueListVisitor<VariableElement, String> visitor = new ValueAnnotationValueListVisitor<>(
             variableElement -> variableElement.getSimpleName().toString() );
         List<String> value = visitList( annotationValue, visitor, VariableElement.class );
         List<String> defaultValue = visitList( annotationDefaultValue, visitor, VariableElement.class );
+
+        return new GemValue<>( value, defaultValue, annotationValue );
+    }
+
+    public static <E extends Enum<E>> GemValue<List<E>> createEnumArray(AnnotationValue annotationValue,
+                                                         AnnotationValue annotationDefaultValue,
+                                                         Class<E> enumClass) {
+        ValueAnnotationValueListVisitor<VariableElement, E> visitor = new ValueAnnotationValueListVisitor<>(
+                variableElement -> Enum.valueOf( enumClass, variableElement.getSimpleName().toString() ) );
+        List<E> value = visitList( annotationValue, visitor, VariableElement.class );
+        List<E> defaultValue = visitList( annotationDefaultValue, visitor, VariableElement.class );
 
         return new GemValue<>( value, defaultValue, annotationValue );
     }

--- a/api/src/main/java/org/mapstruct/tools/gem/RegisterGem.java
+++ b/api/src/main/java/org/mapstruct/tools/gem/RegisterGem.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.tools.gem;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Registers the annotated {@code enum} as the gem enum for {@code value()}.
+ * The annotated enum must contain exactly all constants of the {@code enum} specified in {@code value()}.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ ElementType.TYPE })
+public @interface RegisterGem {
+
+    /**
+     * @return the {@code enum} which should be represented by the annotated class.
+     */
+    Class<? extends Enum<?>> value();
+}

--- a/api/src/test/java/org/mapstruct/tools/gem/GemValueTest.java
+++ b/api/src/test/java/org/mapstruct/tools/gem/GemValueTest.java
@@ -5,17 +5,27 @@
  */
 package org.mapstruct.tools.gem;
 
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import javax.lang.model.element.AnnotationValue;
-import javax.lang.model.element.AnnotationValueVisitor;
-
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.AnnotationValueVisitor;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ElementVisitor;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 class GemValueTest {
 
@@ -124,6 +134,25 @@ class GemValueTest {
         }
     }
 
+    static class GenericArrayAnnotationValue implements AnnotationValue {
+
+        private final List<AnnotationValue> value;
+
+        GenericArrayAnnotationValue(AnnotationValue... values) {
+            this.value = java.util.Arrays.asList( values );
+        }
+
+        @Override
+        public Object getValue() {
+            return value;
+        }
+
+        @Override
+        public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+            return v.visitArray( value, p );
+        }
+    }
+
     @Nested
     class CreateArrayTest {
 
@@ -190,6 +219,394 @@ class GemValueTest {
             assertThat( gemValue.getAnnotationValue() ).isNull();
             assertThat( gemValue.getValueOrElseGet( () -> Collections.singletonList( 3 ) ) )
                     .as( "getValueOrElseGet should return other" ).isEqualTo( Collections.singletonList( 3 ) );
+        }
+    }
+
+    @Nested
+    class CreateEnumAsStringValueTest {
+
+        @Test
+        void createSimpleValue() {
+            EnumAnnotationValue annotationValue = new EnumAnnotationValue( TestEnum.A );
+            GemValue<String> gemValue = GemValue.createEnum( annotationValue, new EnumAnnotationValue( TestEnum.B ) );
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isTrue();
+            assertThat( gemValue.getValue() ).isEqualTo( "A" );
+            assertThat( gemValue.getDefaultValue() ).isEqualTo( "B" );
+            assertThat( gemValue.get() ).as( "get should return value" ).isEqualTo( "A" );
+            assertThat( gemValue.getAnnotationValue() ).isEqualTo( annotationValue );
+            assertThat( gemValue.getValueOrElseGet( () -> "C" ) )
+                    .as( "getValueOrElseGet should return value" ).isEqualTo( "A" );
+        }
+
+        @Test
+        void createSimpleValueWithoutAnnotationValue() {
+            GemValue<String> gemValue = GemValue.createEnum( null, new EnumAnnotationValue( TestEnum.B ) );
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isFalse();
+            assertThat( gemValue.getValue() ).isNull();
+            assertThat( gemValue.getDefaultValue() ).isEqualTo( "B" );
+            assertThat( gemValue.get() ).as( "get should return defaultValue" ).isEqualTo( "B" );
+            assertThat( gemValue.getAnnotationValue() ).isNull();
+            assertThat( gemValue.getValueOrElseGet( () -> "C" ) )
+                    .as( "getValueOrElseGet should return other" ).isEqualTo( "C" );
+        }
+
+        @Test
+        void createSimpleValueWithoutAnnotationDefaultValue() {
+            EnumAnnotationValue annotationValue = new EnumAnnotationValue( TestEnum.A );
+            GemValue<String> gemValue = GemValue.createEnum( annotationValue, null );
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isTrue();
+            assertThat( gemValue.getValue() ).isEqualTo( "A" );
+            assertThat( gemValue.getDefaultValue() ).isNull();
+            assertThat( gemValue.get() ).as( "get should return value" ).isEqualTo( "A" );
+            assertThat( gemValue.getAnnotationValue() ).isEqualTo( annotationValue );
+            assertThat( gemValue.getValueOrElseGet( () -> "C" ) )
+                    .as( "getValueOrElseGet should return value" ).isEqualTo( "A" );
+        }
+
+        @Test
+        void createSimpleValueInvalid() {
+            GemValue<String> gemValue = GemValue.createEnum( null, null );
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isFalse();
+            assertThat( gemValue.hasValue() ).isFalse();
+            assertThat( gemValue.getValue() ).isNull();
+            assertThat( gemValue.getDefaultValue() ).isNull();
+            assertThat( gemValue.get() ).as( "get should return null" ).isNull();
+            assertThat( gemValue.getAnnotationValue() ).isNull();
+            assertThat( gemValue.getValueOrElseGet( () -> "C" ) )
+                    .as( "getValueOrElseGet should return other" ).isEqualTo( "C" );
+        }
+    }
+
+    @Nested
+    class CreateEnumArrayTest {
+
+        @Test
+        void createEnumArrayValue() {
+            EnumAnnotationValue annotationValue = new EnumAnnotationValue( TestEnum.A );
+            EnumAnnotationValue defaultAnnotationValue = new EnumAnnotationValue( TestEnum.B );
+
+            GenericArrayAnnotationValue arrayValue = new GenericArrayAnnotationValue( annotationValue );
+            GenericArrayAnnotationValue defaultArrayValue = new GenericArrayAnnotationValue( defaultAnnotationValue );
+
+            GemValue<List<String>> gemValue = GemValue.createEnumArray( arrayValue, defaultArrayValue );
+
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isTrue();
+            assertThat( gemValue.getValue() ).isEqualTo( Collections.singletonList( "A" ) );
+            assertThat( gemValue.getDefaultValue() ).isEqualTo( Collections.singletonList( "B" ) );
+            assertThat( gemValue.get() ).as( "get should return value" ).isEqualTo( Collections.singletonList( "A" ) );
+            assertThat( gemValue.getAnnotationValue() ).isEqualTo( arrayValue );
+            assertThat( gemValue.getValueOrElseGet( Collections::emptyList ) )
+                    .as( "getValueOrElseGet should return value" ).isEqualTo( Collections.singletonList( "A" ) );
+        }
+
+        @Test
+        void createEnumArrayValueWithoutAnnotationValue() {
+            EnumAnnotationValue defaultAnnotationValue = new EnumAnnotationValue( TestEnum.B );
+            GenericArrayAnnotationValue defaultArrayValue = new GenericArrayAnnotationValue( defaultAnnotationValue );
+
+            GemValue<List<String>> gemValue = GemValue.createEnumArray( null, defaultArrayValue );
+
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isFalse();
+            assertThat( gemValue.getValue() ).isNull();
+            assertThat( gemValue.getDefaultValue() ).isEqualTo( Collections.singletonList( "B" ) );
+            assertThat( gemValue.get() ).as( "get should return defaultValue" )
+                    .isEqualTo( Collections.singletonList( "B" ) );
+            assertThat( gemValue.getAnnotationValue() ).isNull();
+            assertThat( gemValue.getValueOrElseGet( Collections::emptyList ) )
+                    .as( "getValueOrElseGet should return other" ).isEqualTo( Collections.emptyList() );
+        }
+
+        @Test
+        void createEnumArrayValueWithoutAnnotationDefaultValue() {
+            EnumAnnotationValue annotationValue = new EnumAnnotationValue( TestEnum.A );
+            GenericArrayAnnotationValue arrayValue = new GenericArrayAnnotationValue( annotationValue );
+
+            GemValue<List<String>> gemValue = GemValue.createEnumArray( arrayValue, null );
+
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isTrue();
+            assertThat( gemValue.getValue() ).isEqualTo( Collections.singletonList( "A" ) );
+            assertThat( gemValue.getDefaultValue() ).isNull();
+            assertThat( gemValue.get() ).as( "get should return value" ).isEqualTo( Collections.singletonList( "A" ) );
+            assertThat( gemValue.getAnnotationValue() ).isEqualTo( arrayValue );
+            assertThat( gemValue.getValueOrElseGet( Collections::emptyList ) )
+                    .as( "getValueOrElseGet should return value" ).isEqualTo( Collections.singletonList( "A" ) );
+        }
+
+        @Test
+        void createEnumArrayValueInvalid() {
+            GemValue<List<String>> gemValue = GemValue.createEnumArray( null, null );
+
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isFalse();
+            assertThat( gemValue.hasValue() ).isFalse();
+            assertThat( gemValue.getValue() ).isNull();
+            assertThat( gemValue.getDefaultValue() ).isNull();
+            assertThat( gemValue.get() ).as( "get should return null" ).isNull();
+            assertThat( gemValue.getAnnotationValue() ).isNull();
+            assertThat( gemValue.getValueOrElseGet( Collections::emptyList ) )
+                    .as( "getValueOrElseGet should return other" ).isEqualTo( Collections.emptyList() );
+        }
+    }
+
+    @Nested
+    class CreateEnumAsEnumTest {
+
+        @Test
+        void createSimpleValue() {
+            EnumAnnotationValue annotationValue = new EnumAnnotationValue( TestEnum.A );
+            GemValue<TestEnum> gemValue = GemValue.createEnum( annotationValue, new EnumAnnotationValue( TestEnum.B ),
+                    TestEnum.class );
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isTrue();
+            assertThat( gemValue.getValue() ).isEqualTo( TestEnum.A );
+            assertThat( gemValue.getDefaultValue() ).isEqualTo( TestEnum.B );
+            assertThat( gemValue.get() ).as( "get should return value" ).isEqualTo( TestEnum.A );
+            assertThat( gemValue.getAnnotationValue() ).isEqualTo( annotationValue );
+            assertThat( gemValue.getValueOrElseGet( () -> TestEnum.C ) )
+                    .as( "getValueOrElseGet should return value" ).isEqualTo( TestEnum.A );
+        }
+
+        @Test
+        void createSimpleValueWithoutAnnotationValue() {
+            GemValue<TestEnum> gemValue = GemValue.createEnum( null, new EnumAnnotationValue( TestEnum.B ),
+                    TestEnum.class );
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isFalse();
+            assertThat( gemValue.getValue() ).isNull();
+            assertThat( gemValue.getDefaultValue() ).isEqualTo( TestEnum.B );
+            assertThat( gemValue.get() ).as( "get should return defaultValue" ).isEqualTo( TestEnum.B );
+            assertThat( gemValue.getAnnotationValue() ).isNull();
+            assertThat( gemValue.getValueOrElseGet( () -> TestEnum.C ) )
+                    .as( "getValueOrElseGet should return other" ).isEqualTo( TestEnum.C );
+        }
+
+        @Test
+        void createSimpleValueWithoutAnnotationDefaultValue() {
+            EnumAnnotationValue annotationValue = new EnumAnnotationValue( TestEnum.A );
+            GemValue<TestEnum> gemValue = GemValue.createEnum( annotationValue, null, TestEnum.class );
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isTrue();
+            assertThat( gemValue.getValue() ).isEqualTo(  TestEnum.A  );
+            assertThat( gemValue.getDefaultValue() ).isNull();
+            assertThat( gemValue.get() ).as( "get should return value" ).isEqualTo(  TestEnum.A  );
+            assertThat( gemValue.getAnnotationValue() ).isEqualTo( annotationValue );
+            assertThat( gemValue.getValueOrElseGet( () ->  TestEnum.C ) )
+                    .as( "getValueOrElseGet should return value" ).isEqualTo(  TestEnum.A );
+        }
+
+        @Test
+        void createSimpleValueInvalid() {
+            GemValue<TestEnum> gemValue = GemValue.createEnum( null, null, TestEnum.class );
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isFalse();
+            assertThat( gemValue.hasValue() ).isFalse();
+            assertThat( gemValue.getValue() ).isNull();
+            assertThat( gemValue.getDefaultValue() ).isNull();
+            assertThat( gemValue.get() ).as( "get should return null" ).isNull();
+            assertThat( gemValue.getAnnotationValue() ).isNull();
+            assertThat( gemValue.getValueOrElseGet( () -> TestEnum.C ) )
+                    .as( "getValueOrElseGet should return other" ).isEqualTo( TestEnum.C );
+        }
+    }
+
+    @Nested
+    class CreateEnumArrayAsEnumTest {
+
+        @Test
+        void createEnumArrayValue() {
+            EnumAnnotationValue annotationValue = new EnumAnnotationValue( TestEnum.A );
+            EnumAnnotationValue defaultAnnotationValue = new EnumAnnotationValue( TestEnum.B );
+
+            GenericArrayAnnotationValue arrayValue = new GenericArrayAnnotationValue( annotationValue );
+            GenericArrayAnnotationValue defaultArrayValue = new GenericArrayAnnotationValue( defaultAnnotationValue );
+
+            GemValue<List<TestEnum>> gemValue = GemValue.createEnumArray( arrayValue, defaultArrayValue,
+                    TestEnum.class );
+
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isTrue();
+            assertThat( gemValue.getValue() ).isEqualTo( Collections.singletonList( TestEnum.A ) );
+            assertThat( gemValue.getDefaultValue() ).isEqualTo( Collections.singletonList( TestEnum.B ) );
+            assertThat( gemValue.get() ).as( "get should return value" )
+                    .isEqualTo( Collections.singletonList( TestEnum.A ) );
+            assertThat( gemValue.getAnnotationValue() ).isEqualTo( arrayValue );
+            assertThat( gemValue.getValueOrElseGet( Collections::emptyList ) )
+                    .as( "getValueOrElseGet should return value" ).isEqualTo( Collections.singletonList( TestEnum.A ) );
+        }
+
+        @Test
+        void createEnumArrayValueWithoutAnnotationValue() {
+            EnumAnnotationValue defaultAnnotationValue = new EnumAnnotationValue( TestEnum.B );
+            GenericArrayAnnotationValue defaultArrayValue = new GenericArrayAnnotationValue( defaultAnnotationValue );
+
+            GemValue<List<TestEnum>> gemValue = GemValue.createEnumArray( null, defaultArrayValue, TestEnum.class );
+
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isFalse();
+            assertThat( gemValue.getValue() ).isNull();
+            assertThat( gemValue.getDefaultValue() ).isEqualTo( Collections.singletonList( TestEnum.B ) );
+            assertThat( gemValue.get() ).as( "get should return defaultValue" )
+                    .isEqualTo( Collections.singletonList( TestEnum.B ) );
+            assertThat( gemValue.getAnnotationValue() ).isNull();
+            assertThat( gemValue.getValueOrElseGet( Collections::emptyList ) )
+                    .as( "getValueOrElseGet should return other" ).isEqualTo( Collections.emptyList() );
+        }
+
+        @Test
+        void createEnumArrayValueWithoutAnnotationDefaultValue() {
+            EnumAnnotationValue annotationValue = new EnumAnnotationValue( TestEnum.A );
+            GenericArrayAnnotationValue arrayValue = new GenericArrayAnnotationValue( annotationValue );
+
+            GemValue<List<TestEnum>> gemValue = GemValue.createEnumArray( arrayValue, null, TestEnum.class );
+
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isTrue();
+            assertThat( gemValue.hasValue() ).isTrue();
+            assertThat( gemValue.getValue() ).isEqualTo( Collections.singletonList( TestEnum.A ) );
+            assertThat( gemValue.getDefaultValue() ).isNull();
+            assertThat( gemValue.get() ).as( "get should return value" )
+                    .isEqualTo( Collections.singletonList( TestEnum.A ) );
+            assertThat( gemValue.getAnnotationValue() ).isEqualTo( arrayValue );
+            assertThat( gemValue.getValueOrElseGet( Collections::emptyList ) )
+                    .as( "getValueOrElseGet should return value" ).isEqualTo( Collections.singletonList( TestEnum.A ) );
+        }
+
+        @Test
+        void createEnumArrayValueInvalid() {
+            GemValue<List<TestEnum>> gemValue = GemValue.createEnumArray( null, null, TestEnum.class );
+
+            assertThat( gemValue ).isNotNull();
+            assertThat( gemValue.isValid() ).isFalse();
+            assertThat( gemValue.hasValue() ).isFalse();
+            assertThat( gemValue.getValue() ).isNull();
+            assertThat( gemValue.getDefaultValue() ).isNull();
+            assertThat( gemValue.get() ).as( "get should return null" ).isNull();
+            assertThat( gemValue.getAnnotationValue() ).isNull();
+            assertThat( gemValue.getValueOrElseGet( Collections::emptyList ) )
+                    .as( "getValueOrElseGet should return other" ).isEqualTo( Collections.emptyList() );
+        }
+    }
+
+
+    enum TestEnum {
+        A, B, C
+    }
+
+    static class EnumAnnotationValue implements AnnotationValue {
+
+        private final String value;
+
+        EnumAnnotationValue(TestEnum value) {
+            this.value = value.toString();
+        }
+
+        @Override
+        public Object getValue() {
+            return value;
+        }
+
+        @Override
+        public <R, P> R accept(AnnotationValueVisitor<R, P> v, P p) {
+            VariableElement variableElement = new VariableElement() {
+                @Override
+                public TypeMirror asType() {
+                    return null;
+                }
+
+                @Override
+                public Object getConstantValue() {
+                    return null;
+                }
+
+                @Override
+                public Name getSimpleName() {
+                    return new Name() {
+                        @Override
+                        public boolean contentEquals(CharSequence cs) {
+                            return cs.toString().equals( value );
+                        }
+
+                        @Override
+                        public int length() {
+                            return  value.length();
+                        }
+
+                        @Override
+                        public char charAt(int index) {
+                            return value.charAt( index );
+                        }
+
+                        @Override
+                        public CharSequence subSequence(int start, int end) {
+                            return value.subSequence( start, end );
+                        }
+
+                        @Override
+                        public String toString() {
+                            return value;
+                        }
+                    };
+                }
+
+                @Override
+                public Element getEnclosingElement() {
+                    return null;
+                }
+
+                @Override
+                public ElementKind getKind() {
+                    return null;
+                }
+
+                @Override
+                public Set<Modifier> getModifiers() {
+                    return new HashSet<>();
+                }
+
+                @Override
+                public List<? extends Element> getEnclosedElements() {
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public List<? extends AnnotationMirror> getAnnotationMirrors() {
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+                    return null;
+                }
+
+                @Override
+                public <A extends Annotation> A[] getAnnotationsByType(Class<A> annotationType) {
+                    return null;
+                }
+
+                @Override
+                public <S, T> S accept(ElementVisitor<S, T> v, T p) {
+                    return null;
+                }
+            };
+            return v.visitEnumConstant( variableElement, p );
         }
     }
 }

--- a/processor/src/main/java/org/mapstruct/tools/gem/processor/GemEnum.java
+++ b/processor/src/main/java/org/mapstruct/tools/gem/processor/GemEnum.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.tools.gem.processor;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.lang.model.element.Element;
+
+public class GemEnum {
+    private final String gemPackageName;
+    private final String gemName;
+    private final String originalEnumFullName;
+    private final List<String> enumConstants;
+    private final Element[] originatingElements;
+
+    public GemEnum(String gemPackageName, String gemName, String originalEnumFullName,
+                   List<String> values, Element... originatingElements) {
+        this.gemPackageName = gemPackageName;
+        this.gemName = gemName;
+        this.originalEnumFullName = originalEnumFullName;
+        this.enumConstants = values;
+        this.originatingElements = Arrays.copyOf( originatingElements, originatingElements.length );
+    }
+
+    public String getGemPackageName() {
+        return gemPackageName;
+    }
+
+    public String getGemName() {
+        return gemName;
+    }
+
+    public String getOriginalEnumFullName() {
+        return originalEnumFullName;
+    }
+
+    public List<String> getEnumConstants() {
+        return enumConstants;
+    }
+
+    public Element[] getOriginatingElements() {
+        return originatingElements;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/tools/gem/processor/GemInfo.java
+++ b/processor/src/main/java/org/mapstruct/tools/gem/processor/GemInfo.java
@@ -81,11 +81,11 @@ public class GemInfo {
     }
 
     private boolean isNotSamePackage(GemValueType valueType ) {
-        return !valueType.getPacakage().equals( gemPackageName );
+        return !valueType.getPackageName().equals( gemPackageName );
     }
 
     private boolean isNotJavaLang( GemValueType valueType ) {
-        return !"java.lang".equals( valueType.getPacakage() );
+        return !"java.lang".equals( valueType.getPackageName() );
     }
 
     private boolean isNotTypeMirror( GemValueType valueType ) {

--- a/processor/src/main/java/org/mapstruct/tools/gem/processor/GemProcessor.java
+++ b/processor/src/main/java/org/mapstruct/tools/gem/processor/GemProcessor.java
@@ -11,6 +11,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,7 +22,9 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.ArrayType;
@@ -34,16 +37,19 @@ import javax.tools.Diagnostic;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
-import freemarker.template.Version;
 
 /**
  * @author sjaakd
  */
-@SupportedAnnotationTypes( {"org.mapstruct.tools.gem.GemDefinitions", "org.mapstruct.tools.gem.GemDefinition"} )
+@SupportedAnnotationTypes( {"org.mapstruct.tools.gem.GemDefinitions", "org.mapstruct.tools.gem.GemDefinition",
+        "org.mapstruct.tools.gem.RegisterGem"} )
 public class GemProcessor extends AbstractProcessor {
 
     private Util util;
-    private List<GemInfo> gemInfos = new ArrayList<>( 10 );
+    private final List<GemInfo> gemInfos = new ArrayList<>( 10 );
+    private final List<GemEnum> gemEnums = new ArrayList<>();
+    private final Map<String, GemEnum> gemEnumMap = new HashMap<>();
+    private boolean noErrors = true;
 
     @Override
     public SourceVersion getSupportedSourceVersion() {
@@ -74,13 +80,18 @@ public class GemProcessor extends AbstractProcessor {
                         );
                         gemDefinitionMirrors.forEach( m -> addGemInfo( m, definingElement ) );
                     }
+                    else if ( "org.mapstruct.tools.gem.RegisterGem".equals( annotationName ) ) {
+                        addEnumMapping( gemDefinitionsMirror, definingElement );
+                    }
                     else {
                         addGemInfo( gemDefinitionsMirror, definingElement );
                     }
                 }
             }
-            postProcessGemInfo();
-            write();
+            if ( noErrors ) {
+                postProcessGemInfo();
+                write();
+            }
         }
         catch ( RuntimeException ex ) {
             StringWriter sw = new StringWriter();
@@ -95,27 +106,51 @@ public class GemProcessor extends AbstractProcessor {
 
         // create gem info
         DeclaredType gemDeclaredType = util.getAnnotationValue( gemDefinitionMirror, "value", DeclaredType.class );
+        Element element = gemDeclaredType.asElement();
+        ElementKind kind = element.getKind();
         String annotationName = util.getSimpleName( gemDeclaredType );
         String gemName = getGemName( gemDefinitionMirror, annotationName );
         PackageElement pkg = processingEnv.getElementUtils().getPackageOf( definingElement );
         String gemFqn = util.getFullyQualifiedName( gemDeclaredType );
         String gemPackage = pkg.getQualifiedName().toString();
+        if ( kind == ElementKind.ENUM ) {
+           List<String> enumConstants = getEnumConstants( element );
+            GemEnum gemEnum = new GemEnum(gemPackage, gemName, gemFqn, enumConstants, definingElement, element);
+            gemEnums.add( gemEnum );
+            if ( gemEnumMap.put( gemFqn, gemEnum ) != null ) {
+                processingEnv.getMessager().printMessage( Diagnostic.Kind.ERROR,
+                        "Enum gem " + gemFqn + " can only be registered once" );
+                noErrors = false;
+            }
+        }
+        else if ( kind == ElementKind.ANNOTATION_TYPE ) {
 
-        // collect value info
-        List<ExecutableElement> methods = ElementFilter.methodsIn( gemDeclaredType.asElement().getEnclosedElements() );
-        List<GemValueInfo> gemValueInfos = methods.stream()
-            .map( e -> new GemValueInfo( e.getSimpleName().toString(), e.getReturnType() ) )
-            .collect( Collectors.toList() );
-        GemInfo gemInfo = new GemInfo(
-            gemPackage,
-            gemName,
-            annotationName,
-            gemFqn,
-            gemValueInfos,
-            definingElement,
-            gemDeclaredType.asElement()
-        );
-        gemInfos.add( gemInfo );
+            // collect value info
+            List<ExecutableElement> methods = ElementFilter.methodsIn( element.getEnclosedElements() );
+            List<GemValueInfo> gemValueInfos = methods.stream()
+                    .map( e -> new GemValueInfo( e.getSimpleName().toString(), e.getReturnType() ) )
+                    .collect( Collectors.toList() );
+            GemInfo gemInfo = new GemInfo(
+                    gemPackage,
+                    gemName,
+                    annotationName,
+                    gemFqn,
+                    gemValueInfos,
+                    definingElement,
+                    element
+            );
+            gemInfos.add( gemInfo );
+        }
+        else {
+            throw new IllegalArgumentException();
+        }
+
+    }
+
+    private List<String> getEnumConstants(Element element) {
+        return element.getEnclosedElements().stream()
+                .filter( e -> e.getKind() == ElementKind.ENUM_CONSTANT )
+                .map( Element::getSimpleName ).map( Name::toString ).collect( Collectors.toList() );
     }
 
     private String getGemName(AnnotationMirror gemDefinitionMirror, String annotationName) {
@@ -148,7 +183,13 @@ public class GemProcessor extends AbstractProcessor {
                 DeclaredType declaredType = (DeclaredType) type;
                 String fqn = util.getFullyQualifiedName( declaredType );
                 if ( util.isEnumeration( declaredType ) ) {
-                    valueType = new GemValueType( String.class, true, isArray );
+                    GemEnum gemEnum = gemEnumMap.get( fqn );
+                    if (gemEnum != null) {
+                        valueType = new GemValueType( gemEnum, isArray );
+                    }
+                    else {
+                        valueType = new GemValueType( String.class, true, isArray );
+                    }
                 }
                 else if ( Class.class.getName().equals( fqn ) ) {
                     valueType = new GemValueType( TypeMirror.class, false, isArray );
@@ -157,16 +198,11 @@ public class GemProcessor extends AbstractProcessor {
                     valueType = new GemValueType( String.class, false, isArray );
                 }
                 else {
-                    GemInfo usedGem = gemInfos.stream()
+                    valueType = gemInfos.stream()
                         .filter( g -> fqn.equals( g.getAnnotationFqn() ) )
                         .findFirst()
-                        .orElse( null );
-                    if ( usedGem != null ) {
-                        valueType = new GemValueType( usedGem, isArray );
-                    }
-                    else {
-                        valueType = new GemValueType( TypeMirror.class, false, isArray );
-                    }
+                        .map( usedGem -> new GemValueType( usedGem, isArray ) )
+                        .orElseGet( () -> new GemValueType( TypeMirror.class, false, isArray ) );
                 }
                 break;
             case BOOLEAN:
@@ -199,17 +235,74 @@ public class GemProcessor extends AbstractProcessor {
         return valueType;
     }
 
+    private void addEnumMapping(AnnotationMirror gemDefinitionsMirror, Element definingElement) {
+        if ( definingElement.getKind() != ElementKind.ENUM) {
+            throw new IllegalArgumentException();
+        }
+        String packageName = processingEnv.getElementUtils().getPackageOf( definingElement )
+                .getQualifiedName().toString();
+        DeclaredType original = util.getAnnotationValue( gemDefinitionsMirror, "value", DeclaredType.class );
+        String originalFullName = util.getFullyQualifiedName( original );
+        List<String> originalElements = getEnumConstants( original.asElement() );
+        Set<String> originalValues = new HashSet<>( originalElements );
+        List<String> enumConstants = getEnumConstants( definingElement );
+        Set<String> definedValues =  new HashSet<>( enumConstants );
+        List<String> missingOriginals = originalValues.stream()
+                .filter( value -> !definedValues.remove( value ) ).collect( Collectors.toList() );
+
+        if ( !missingOriginals.isEmpty() ) {
+            processingEnv.getMessager().printMessage( Diagnostic.Kind.ERROR, "Enum constants " + missingOriginals
+                    + " are missing in " + packageName + "." + definingElement.getSimpleName() + ". A enum gem of "
+                    + originalFullName + " should exactly contain " + originalElements );
+            noErrors = false;
+        }
+        if ( !definedValues.isEmpty() ) {
+            processingEnv.getMessager().printMessage( Diagnostic.Kind.ERROR, "Enum constants " + definedValues
+                    + " are only present in " + packageName + "." + definingElement.getSimpleName() + ". A enum gem of "
+                    + originalFullName + " should exactly contain " + originalElements );
+            noErrors = false;
+        }
+        if ( gemEnumMap.put( originalFullName, new GemEnum(
+                packageName,
+                definingElement.getSimpleName().toString(),
+                originalFullName,
+                enumConstants
+        ) ) != null ) {
+             processingEnv.getMessager().printMessage( Diagnostic.Kind.ERROR,
+                     "Enum gem " + originalFullName + " can only be registered once" );
+             noErrors = false;
+         }
+    }
+
     private void write( ) {
+        Configuration cfg = new Configuration(Configuration.VERSION_2_3_29);
+        cfg.setClassForTemplateLoading( GemProcessor.class, "/" );
+        cfg.setDefaultEncoding( "UTF-8" );
+        for (GemEnum gemEnum : gemEnums) {
+            try (Writer writer = processingEnv.getFiler()
+                    .createSourceFile(
+                            gemEnum.getGemPackageName() + "." + gemEnum.getGemName(),
+                            gemEnum.getOriginatingElements()
+                    )
+                    .openWriter() ) {
+                Map<String, Object> templateData = new HashMap<>();
+
+                templateData.put( "gemEnum", gemEnum );
+                Template template = cfg.getTemplate( "org/mapstruct/tools/gem/processor/Enum.ftl" );
+                template.process( templateData, writer );
+                writer.flush();
+            }
+            catch (TemplateException | IOException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
         for ( GemInfo gemInfo : gemInfos ) {
             try (Writer writer = processingEnv.getFiler()
                 .createSourceFile(
                     gemInfo.getGemPackageName() + "." + gemInfo.getGemName(),
                     gemInfo.getOriginatingElements()
                 )
-                .openWriter()) {
-                Configuration cfg = new Configuration( new Version( "2.3.21" ) );
-                cfg.setClassForTemplateLoading( GemProcessor.class, "/" );
-                cfg.setDefaultEncoding( "UTF-8" );
+                .openWriter() ) {
 
                 Map<String, Object> templateData = new HashMap<>();
 
@@ -223,5 +316,7 @@ public class GemProcessor extends AbstractProcessor {
         }
         // handled all info, clear
         gemInfos.clear();
+        gemEnums.clear();
+        gemEnumMap.clear();
     }
 }

--- a/processor/src/main/java/org/mapstruct/tools/gem/processor/GemValueType.java
+++ b/processor/src/main/java/org/mapstruct/tools/gem/processor/GemValueType.java
@@ -9,7 +9,7 @@ public class GemValueType {
 
     private final String name;
     private final String fqn;
-    private final String pacakage;
+    private final String packageName;
     private final boolean isEnum;
     private final boolean isArray;
     private final boolean isGem;
@@ -17,12 +17,23 @@ public class GemValueType {
     private String gemName;
     private String elementName;
 
+    public GemValueType(GemEnum gemEnum, boolean isArray) {
+        this.elementName = gemEnum.getGemName();
+        this.name = isArray ? "List<" + elementName + ">" : elementName;
+        this.fqn = gemEnum.getGemPackageName() + "." + gemEnum.getGemName();
+        this.gemName = gemEnum.getGemName();
+        this.packageName = gemEnum.getGemPackageName();
+        this.isEnum = true;
+        this.isArray = isArray;
+        this.isGem = false;
+    }
+
     public GemValueType(GemInfo gemInfo, boolean isArray) {
         this.elementName = gemInfo.getGemName();
         this.name = isArray ? "List<" + elementName + ">" : elementName;
         this.fqn = gemInfo.getGemPackageName() + "." + gemInfo.getGemName();
         this.gemName = gemInfo.getGemName();
-        this.pacakage = gemInfo.getGemPackageName();
+        this.packageName = gemInfo.getGemPackageName();
         this.isEnum = false;
         this.isArray = isArray;
         this.isGem = true;
@@ -32,7 +43,7 @@ public class GemValueType {
         this.elementName = clazz.getSimpleName();
         this.name = isArray ? "List<" + clazz.getSimpleName() + ">" : clazz.getSimpleName();
         this.fqn = clazz.getName();
-        this.pacakage = clazz.getPackage().getName();
+        this.packageName = clazz.getPackage().getName();
         this.isEnum = isEnum;
         this.isArray = isArray;
         this.isGem = false;
@@ -42,8 +53,8 @@ public class GemValueType {
         return fqn;
     }
 
-    public String getPacakage() {
-        return pacakage;
+    public String getPackageName() {
+        return packageName;
     }
 
     public String getName() {

--- a/processor/src/main/resources/org/mapstruct/tools/gem/processor/Enum.ftl
+++ b/processor/src/main/resources/org/mapstruct/tools/gem/processor/Enum.ftl
@@ -1,0 +1,18 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="gemEnum" type="org.mapstruct.tools.gem.processor.GemEnum" -->
+package ${gemEnum.gemPackageName};
+
+/**
+ * Gem for the enum {@link ${gemEnum.originalEnumFullName}}
+*/
+public enum ${gemEnum.gemName} {
+<#list gemEnum.enumConstants as enumConstant>
+    ${enumConstant}<#if enumConstant?has_next>,</#if>
+</#list>
+}

--- a/processor/src/main/resources/org/mapstruct/tools/gem/processor/Gem.ftl
+++ b/processor/src/main/resources/org/mapstruct/tools/gem/processor/Gem.ftl
@@ -213,9 +213,17 @@ public class ${gemInfo.gemName} implements Gem {
         </#if>
     <#elseif gemValueInfo.valueType.enum>
         <#if gemValueInfo.valueType.array>
+            <#if gemValueInfo.valueType.elementName == "String">
                     GemValue.createEnumArray( value, defaultValue )
+            <#else>
+                    GemValue.createEnumArray( value, defaultValue, ${gemValueInfo.valueType.elementName}.class  )
+            </#if>
         <#else>
+            <#if gemValueInfo.valueType.elementName == "String">
                     GemValue.createEnum( value, defaultValue )
+            <#else>
+                    GemValue.createEnum( value, defaultValue, ${gemValueInfo.valueType.elementName}.class  )
+            </#if>
         </#if>
     <#else>
         <#if gemValueInfo.valueType.array>

--- a/processor/src/test/java/org/mapstruct/tools/gem/processor/ProcessorTest.java
+++ b/processor/src/test/java/org/mapstruct/tools/gem/processor/ProcessorTest.java
@@ -6,14 +6,15 @@
 package org.mapstruct.tools.gem.processor;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import javax.annotation.processing.Processor;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
@@ -24,10 +25,10 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class ProcessorTest {
 
@@ -65,10 +66,219 @@ class ProcessorTest {
         assertGeneratedFileContent( "BuilderGem", generatedDir );
     }
 
+    @Test
+    void generateEnum() throws IOException {
+        StringJavaFileObject src = new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.GemGenerator",
+                "package org.mapstruct.tools.gem.processor;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.GemDefinition;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.EnumAnnotation;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.SimpleEnum;\n" +
+                        "\n" +
+                        "@GemDefinition(value = SimpleEnum.class)\n" +
+                        "@GemDefinition(value = EnumAnnotation.class)\n" +
+                        "public class GemGenerator {\n" +
+                        "}"
+        );
+        File generatedDir = compile( new GemProcessor(), src );
+        assertGeneratedFileContent( "SimpleEnumGem", generatedDir );
+        assertGeneratedFileContent( "EnumAnnotationGem", generatedDir );
+    }
+
+    @Test
+    void generateEnumWithRegisterGem() throws IOException {
+        StringJavaFileObject src = new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.GemGenerator",
+                "package org.mapstruct.tools.gem.processor;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.GemDefinition;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.EnumAnnotation;\n" +
+                        "\n" +
+                        "@GemDefinition(value = EnumAnnotation.class," +
+                        " implementationName = \"<CLASS_NAME>RegisterGem\")\n" +
+                        "public class GemGenerator {\n" +
+                        "}"
+        );
+        File generatedDir = compile( new GemProcessor(), src, getManuelGemOfEnum() );
+        assertGeneratedFileContent( "EnumAnnotationRegisterGem", generatedDir );
+    }
+
+    @Test
+    void generateEnumWithRegisterOtherPackageGem() throws IOException {
+        StringJavaFileObject src = new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.GemGenerator",
+                "package org.mapstruct.tools.gem.processor;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.GemDefinition;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.EnumAnnotation;\n" +
+                        "\n" +
+                        "@GemDefinition(value = EnumAnnotation.class," +
+                        " implementationName = \"<CLASS_NAME>PackageGem\")\n" +
+                        "public class GemGenerator {\n" +
+                        "}"
+        );
+        StringJavaFileObject enumSr = new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.other.MySimpleEnumGem",
+                "package org.mapstruct.tools.gem.processor.other;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.RegisterGem;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.SimpleEnum;\n" +
+                        "\n" +
+                        "@RegisterGem(value = SimpleEnum.class)\n" +
+                        "public enum MySimpleEnumGem {\n" +
+                        "A,B,C;\n" +
+                        "}"
+        );
+        File generatedDir = compile( new GemProcessor(), enumSr, src );
+        assertGeneratedFileContent( "EnumAnnotationPackageGem", generatedDir );
+    }
+
+    @Test
+    void registerGem() throws IOException {
+        compile( new GemProcessor(), getManuelGemOfEnum() );
+    }
+
+    @Test
+    void registerGemMissingEnumConstants() throws IOException {
+        StringJavaFileObject src = new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.MySimpleEnumGem",
+                "package org.mapstruct.tools.gem.processor;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.RegisterGem;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.SimpleEnum;\n" +
+                        "\n" +
+                        "@RegisterGem(value = SimpleEnum.class)\n" +
+                        "public enum MySimpleEnumGem {\n" +
+                        "C;\n" +
+                        "}"
+        );
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = failCompile( new GemProcessor(), src );
+        assertThat( diagnostics ).singleElement()
+                .extracting(
+                        Diagnostic::getKind,
+                        d -> d.getMessage( null )
+                )
+                .containsExactly(
+                        Diagnostic.Kind.ERROR,
+                        "Enum constants [A, B] are missing in org.mapstruct.tools.gem.processor.MySimpleEnumGem." +
+                                " A enum gem of org.mapstruct.tools.gem.test.enummapping.SimpleEnum should exactly" +
+                                " contain [A, B, C]" );
+    }
+
+    @Test
+    void registerGemMoreEnumConstants() throws IOException {
+        StringJavaFileObject src = new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.MySimpleEnumGem",
+                "package org.mapstruct.tools.gem.processor;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.RegisterGem;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.SimpleEnum;\n" +
+                        "\n" +
+                        "@RegisterGem(value = SimpleEnum.class)\n" +
+                        "public enum MySimpleEnumGem {\n" +
+                        "A,B,C,D,E;\n" +
+                        "}"
+        );
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = failCompile( new GemProcessor(), src );
+        assertThat( diagnostics ).singleElement()
+                .extracting(
+                        Diagnostic::getKind,
+                        d -> d.getMessage( null )
+                )
+                .containsExactly(
+                        Diagnostic.Kind.ERROR,
+                        "Enum constants [D, E] are only present in org.mapstruct.tools.gem.processor.MySimpleEnumGem." +
+                                " A enum gem of org.mapstruct.tools.gem.test.enummapping.SimpleEnum should exactly" +
+                                " contain [A, B, C]"
+                );
+    }
+
+    @Test
+    void registerEnumTwiceGeneratorFirst() throws IOException {
+        StringJavaFileObject src = new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.GemGenerator",
+                "package org.mapstruct.tools.gem.processor;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.GemDefinition;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.SimpleEnum;\n" +
+                        "\n" +
+                        "@GemDefinition(value = SimpleEnum.class)\n" +
+                        "public class GemGenerator {\n" +
+                        "}"
+        );
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = failCompile( new GemProcessor(),
+                src, getManuelGemOfEnum() );
+        assertThat( diagnostics ).singleElement()
+                .extracting(
+                        Diagnostic::getKind,
+                        d -> d.getMessage( null )
+                )
+                .containsExactly(
+                        Diagnostic.Kind.ERROR,
+                        "Enum gem org.mapstruct.tools.gem.test.enummapping.SimpleEnum can only be registered once"
+                );
+    }
+
+    @Test
+    void registerEnumTwiceGemDefinitionFirst() throws IOException {
+        StringJavaFileObject src = new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.GemGenerator",
+                "package org.mapstruct.tools.gem.processor;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.GemDefinition;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.SimpleEnum;\n" +
+                        "\n" +
+                        "@GemDefinition(value = SimpleEnum.class)\n" +
+                        "public class GemGenerator {\n" +
+                        "}"
+        );
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = failCompile( new GemProcessor(),
+                getManuelGemOfEnum(), src );
+        assertThat( diagnostics ).singleElement()
+                .extracting(
+                        Diagnostic::getKind,
+                        d -> d.getMessage( null )
+                )
+                .containsExactly(
+                        Diagnostic.Kind.ERROR,
+                        "Enum gem org.mapstruct.tools.gem.test.enummapping.SimpleEnum can only be registered once"
+                );
+    }
+
+    private List<Diagnostic<? extends JavaFileObject>> failCompile(Processor processor,
+                                                                   JavaFileObject... compilationUnits)
+            throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        StandardJavaFileManager fileManager = compiler.getStandardFileManager( diagnostics, null, null );
+        File classesDir = newFolder( tempDir, "classes" );
+        fileManager.setLocation( StandardLocation.CLASS_OUTPUT, Collections.singletonList( classesDir ) );
+        File generatedDir = newFolder( tempDir, "generated" );
+        fileManager.setLocation( StandardLocation.SOURCE_OUTPUT, Collections.singletonList( generatedDir ) );
+
+        JavaCompiler.CompilationTask task = compiler.getTask(
+                null,
+                fileManager,
+                diagnostics,
+                null,
+                null,
+                Arrays.asList( compilationUnits )
+        );
+
+        task.setProcessors( Collections.singletonList(
+                processor
+        ) );
+
+        assertThat( task.call() ).isFalse();
+        return diagnostics.getDiagnostics();
+    }
+
     private File compile(Processor processor, JavaFileObject... compilationUnits) throws IOException {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
-        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
         StandardJavaFileManager fileManager = compiler.getStandardFileManager( diagnostics, null, null );
         File classesDir = newFolder( tempDir, "classes" );
         fileManager.setLocation( StandardLocation.CLASS_OUTPUT, Collections.singletonList( classesDir ) );
@@ -84,8 +294,8 @@ class ProcessorTest {
             Arrays.asList( compilationUnits )
         );
 
-        task.setProcessors( Arrays.asList(
-            processor
+        task.setProcessors( Collections.singletonList(
+                processor
         ) );
 
         boolean success = task.call();
@@ -102,7 +312,7 @@ class ProcessorTest {
             .as( gemName )
             .exists();
 
-        try (InputStream generatedGemStream = new FileInputStream( gemPath.toFile() );
+        try (InputStream generatedGemStream = Files.newInputStream( gemPath.toFile().toPath() );
              InputStream expectedGemStream = getClass().getClassLoader()
                  .getResourceAsStream( "fixtures/org/mapstruct/tools/gem/processor/" + gemName + ".java" )
         ) {
@@ -128,7 +338,7 @@ class ProcessorTest {
         }
 
         @Override
-        public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
             return code;
         }
     }
@@ -149,6 +359,21 @@ class ProcessorTest {
             "@GemDefinition(value = Builder.class, implementationName = \"Custom<CLASS_NAME>Gem\")\n" +
             "public class GemGenerator {\n" +
             "}";
+    }
+
+    private static StringJavaFileObject getManuelGemOfEnum() {
+        return new StringJavaFileObject(
+                "org.mapstruct.annotations.processor.MySimpleEnumGem",
+                "package org.mapstruct.tools.gem.processor;\n" +
+                        "\n" +
+                        "import org.mapstruct.tools.gem.RegisterGem;\n" +
+                        "import org.mapstruct.tools.gem.test.enummapping.SimpleEnum;\n" +
+                        "\n" +
+                        "@RegisterGem(value = SimpleEnum.class)\n" +
+                        "public enum MySimpleEnumGem {\n" +
+                        "A,B,C;\n" +
+                        "}"
+        );
     }
 
     private static File newFolder(File root, String folder) throws IOException {

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/EnumAnnotationGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/EnumAnnotationGem.java
@@ -1,0 +1,231 @@
+package org.mapstruct.tools.gem.processor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import org.mapstruct.tools.gem.Gem;
+import org.mapstruct.tools.gem.GemValue;
+
+
+public class EnumAnnotationGem implements Gem {
+
+    private final GemValue<SimpleEnumGem> mySimpleEnumWithDefault;
+    private final GemValue<List<SimpleEnumGem>> mySimpleEnumArrayWithDefault;
+    private final GemValue<SimpleEnumGem> mySimpleEnum;
+    private final GemValue<List<SimpleEnumGem>> mySimpleEnumArray;
+    private final boolean isValid;
+    private final AnnotationMirror mirror;
+
+    private EnumAnnotationGem( BuilderImpl builder ) {
+        this.mySimpleEnumWithDefault = builder.mySimpleEnumWithDefault;
+        this.mySimpleEnumArrayWithDefault = builder.mySimpleEnumArrayWithDefault;
+        this.mySimpleEnum = builder.mySimpleEnum;
+        this.mySimpleEnumArray = builder.mySimpleEnumArray;
+        isValid = ( this.mySimpleEnumWithDefault != null && this.mySimpleEnumWithDefault.isValid() )
+               && ( this.mySimpleEnumArrayWithDefault != null && this.mySimpleEnumArrayWithDefault.isValid() )
+               && ( this.mySimpleEnum != null && this.mySimpleEnum.isValid() )
+               && ( this.mySimpleEnumArray != null && this.mySimpleEnumArray.isValid() );
+        mirror = builder.mirror;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationGem#mySimpleEnumWithDefault}
+    */
+    public GemValue<SimpleEnumGem> mySimpleEnumWithDefault( ) {
+        return mySimpleEnumWithDefault;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationGem#mySimpleEnumArrayWithDefault}
+    */
+    public GemValue<List<SimpleEnumGem>> mySimpleEnumArrayWithDefault( ) {
+        return mySimpleEnumArrayWithDefault;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationGem#mySimpleEnum}
+    */
+    public GemValue<SimpleEnumGem> mySimpleEnum( ) {
+        return mySimpleEnum;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationGem#mySimpleEnumArray}
+    */
+    public GemValue<List<SimpleEnumGem>> mySimpleEnumArray( ) {
+        return mySimpleEnumArray;
+    }
+
+    @Override
+    public AnnotationMirror mirror( ) {
+        return mirror;
+    }
+
+    @Override
+    public boolean isValid( ) {
+        return isValid;
+    }
+
+    public static EnumAnnotationGem  instanceOn(Element element) {
+        return build( element, new BuilderImpl() );
+    }
+
+    public static EnumAnnotationGem instanceOn(AnnotationMirror mirror ) {
+        return build( mirror, new BuilderImpl() );
+    }
+
+    public static  <T> T  build(Element element, Builder<T> builder) {
+        AnnotationMirror mirror = element.getAnnotationMirrors().stream()
+            .filter( a ->  "org.mapstruct.tools.gem.test.enummapping.EnumAnnotation".contentEquals( ( ( TypeElement )a.getAnnotationType().asElement() ).getQualifiedName() ) )
+            .findAny()
+            .orElse( null );
+        return build( mirror, builder );
+    }
+
+    public static <T> T build(AnnotationMirror mirror, Builder<T> builder ) {
+
+        // return fast
+        if ( mirror == null || builder == null ) {
+            return null;
+        }
+
+        // fetch defaults from all defined values in the annotation type
+        List<ExecutableElement> enclosed = ElementFilter.methodsIn( mirror.getAnnotationType().asElement().getEnclosedElements() );
+        Map<String, AnnotationValue> defaultValues = new HashMap<>( enclosed.size() );
+        enclosed.forEach( e -> defaultValues.put( e.getSimpleName().toString(), e.getDefaultValue() ) );
+
+        // fetch all explicitely set annotation values in the annotation instance
+        Map<String, AnnotationValue> values = new HashMap<>( enclosed.size() );
+        mirror.getElementValues().forEach( (key, value) -> values.put( key.getSimpleName().toString(), value ) );
+
+        // iterate and populate builder
+        for ( Map.Entry<String, AnnotationValue> defaultMethod : defaultValues.entrySet() ) {
+            String methodName = defaultMethod.getKey();
+            AnnotationValue defaultValue = defaultMethod.getValue();
+            AnnotationValue value = values.get( methodName );
+            switch ( methodName ) {
+                case "mySimpleEnumWithDefault":
+                    builder.setMysimpleenumwithdefault( GemValue.createEnum( value, defaultValue, SimpleEnumGem.class ) );
+                    break;
+                case "mySimpleEnumArrayWithDefault":
+                    builder.setMysimpleenumarraywithdefault( GemValue.createEnumArray( value, defaultValue, SimpleEnumGem.class ) );
+                    break;
+                case "mySimpleEnum":
+                    builder.setMysimpleenum( GemValue.createEnum( value, defaultValue, SimpleEnumGem.class ) );
+                    break;
+                case "mySimpleEnumArray":
+                    builder.setMysimpleenumarray( GemValue.createEnumArray( value, defaultValue, SimpleEnumGem.class ) );
+                    break;
+            }
+        }
+        builder.setMirror( mirror );
+        return builder.build();
+    }
+
+    /**
+     * A builder that can be implemented by the user to define custom logic e.g. in the
+     * build method, prior to creating the annotation gem.
+     */
+    public interface Builder<T> {
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationGem#mySimpleEnumWithDefault}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationGem}
+        */
+        Builder<T> setMysimpleenumwithdefault(GemValue<SimpleEnumGem> methodName );
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationGem#mySimpleEnumArrayWithDefault}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationGem}
+        */
+        Builder<T> setMysimpleenumarraywithdefault(GemValue<List<SimpleEnumGem>> methodName );
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationGem#mySimpleEnum}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationGem}
+        */
+        Builder<T> setMysimpleenum(GemValue<SimpleEnumGem> methodName );
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationGem#mySimpleEnumArray}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationGem}
+        */
+        Builder<T> setMysimpleenumarray(GemValue<List<SimpleEnumGem>> methodName );
+
+        /**
+         * Sets the annotation mirror
+         *
+         * @param mirror the mirror which this gem represents
+         *
+         * @return the {@link Builder} for this gem, representing {@link EnumAnnotationGem}
+         */
+          Builder<T> setMirror( AnnotationMirror mirror );
+
+        /**
+         * The build method can be overriden in a custom custom implementation, which allows
+         * the user to define his own custom validation on the annotation.
+         *
+         * @return the representation of the annotation
+         */
+        T build();
+    }
+
+    private static class BuilderImpl implements Builder<EnumAnnotationGem> {
+
+        private GemValue<SimpleEnumGem> mySimpleEnumWithDefault;
+        private GemValue<List<SimpleEnumGem>> mySimpleEnumArrayWithDefault;
+        private GemValue<SimpleEnumGem> mySimpleEnum;
+        private GemValue<List<SimpleEnumGem>> mySimpleEnumArray;
+        private AnnotationMirror mirror;
+
+        public Builder<EnumAnnotationGem> setMysimpleenumwithdefault(GemValue<SimpleEnumGem> mySimpleEnumWithDefault ) {
+            this.mySimpleEnumWithDefault = mySimpleEnumWithDefault;
+            return this;
+        }
+
+        public Builder<EnumAnnotationGem> setMysimpleenumarraywithdefault(GemValue<List<SimpleEnumGem>> mySimpleEnumArrayWithDefault ) {
+            this.mySimpleEnumArrayWithDefault = mySimpleEnumArrayWithDefault;
+            return this;
+        }
+
+        public Builder<EnumAnnotationGem> setMysimpleenum(GemValue<SimpleEnumGem> mySimpleEnum ) {
+            this.mySimpleEnum = mySimpleEnum;
+            return this;
+        }
+
+        public Builder<EnumAnnotationGem> setMysimpleenumarray(GemValue<List<SimpleEnumGem>> mySimpleEnumArray ) {
+            this.mySimpleEnumArray = mySimpleEnumArray;
+            return this;
+        }
+
+        public Builder<EnumAnnotationGem> setMirror( AnnotationMirror mirror ) {
+            this.mirror = mirror;
+            return this;
+        }
+
+        public EnumAnnotationGem build() {
+            return new EnumAnnotationGem( this );
+        }
+    }
+
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/EnumAnnotationPackageGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/EnumAnnotationPackageGem.java
@@ -1,0 +1,232 @@
+package org.mapstruct.tools.gem.processor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import org.mapstruct.tools.gem.Gem;
+import org.mapstruct.tools.gem.GemValue;
+
+import org.mapstruct.tools.gem.processor.other.MySimpleEnumGem;
+
+public class EnumAnnotationPackageGem implements Gem {
+
+    private final GemValue<MySimpleEnumGem> mySimpleEnumWithDefault;
+    private final GemValue<List<MySimpleEnumGem>> mySimpleEnumArrayWithDefault;
+    private final GemValue<MySimpleEnumGem> mySimpleEnum;
+    private final GemValue<List<MySimpleEnumGem>> mySimpleEnumArray;
+    private final boolean isValid;
+    private final AnnotationMirror mirror;
+
+    private EnumAnnotationPackageGem( BuilderImpl builder ) {
+        this.mySimpleEnumWithDefault = builder.mySimpleEnumWithDefault;
+        this.mySimpleEnumArrayWithDefault = builder.mySimpleEnumArrayWithDefault;
+        this.mySimpleEnum = builder.mySimpleEnum;
+        this.mySimpleEnumArray = builder.mySimpleEnumArray;
+        isValid = ( this.mySimpleEnumWithDefault != null && this.mySimpleEnumWithDefault.isValid() )
+               && ( this.mySimpleEnumArrayWithDefault != null && this.mySimpleEnumArrayWithDefault.isValid() )
+               && ( this.mySimpleEnum != null && this.mySimpleEnum.isValid() )
+               && ( this.mySimpleEnumArray != null && this.mySimpleEnumArray.isValid() );
+        mirror = builder.mirror;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationPackageGem#mySimpleEnumWithDefault}
+    */
+    public GemValue<MySimpleEnumGem> mySimpleEnumWithDefault( ) {
+        return mySimpleEnumWithDefault;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationPackageGem#mySimpleEnumArrayWithDefault}
+    */
+    public GemValue<List<MySimpleEnumGem>> mySimpleEnumArrayWithDefault( ) {
+        return mySimpleEnumArrayWithDefault;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationPackageGem#mySimpleEnum}
+    */
+    public GemValue<MySimpleEnumGem> mySimpleEnum( ) {
+        return mySimpleEnum;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationPackageGem#mySimpleEnumArray}
+    */
+    public GemValue<List<MySimpleEnumGem>> mySimpleEnumArray( ) {
+        return mySimpleEnumArray;
+    }
+
+    @Override
+    public AnnotationMirror mirror( ) {
+        return mirror;
+    }
+
+    @Override
+    public boolean isValid( ) {
+        return isValid;
+    }
+
+    public static EnumAnnotationPackageGem  instanceOn(Element element) {
+        return build( element, new BuilderImpl() );
+    }
+
+    public static EnumAnnotationPackageGem instanceOn(AnnotationMirror mirror ) {
+        return build( mirror, new BuilderImpl() );
+    }
+
+    public static  <T> T  build(Element element, Builder<T> builder) {
+        AnnotationMirror mirror = element.getAnnotationMirrors().stream()
+            .filter( a ->  "org.mapstruct.tools.gem.test.enummapping.EnumAnnotation".contentEquals( ( ( TypeElement )a.getAnnotationType().asElement() ).getQualifiedName() ) )
+            .findAny()
+            .orElse( null );
+        return build( mirror, builder );
+    }
+
+    public static <T> T build(AnnotationMirror mirror, Builder<T> builder ) {
+
+        // return fast
+        if ( mirror == null || builder == null ) {
+            return null;
+        }
+
+        // fetch defaults from all defined values in the annotation type
+        List<ExecutableElement> enclosed = ElementFilter.methodsIn( mirror.getAnnotationType().asElement().getEnclosedElements() );
+        Map<String, AnnotationValue> defaultValues = new HashMap<>( enclosed.size() );
+        enclosed.forEach( e -> defaultValues.put( e.getSimpleName().toString(), e.getDefaultValue() ) );
+
+        // fetch all explicitely set annotation values in the annotation instance
+        Map<String, AnnotationValue> values = new HashMap<>( enclosed.size() );
+        mirror.getElementValues().forEach( (key, value) -> values.put( key.getSimpleName().toString(), value ) );
+
+        // iterate and populate builder
+        for ( Map.Entry<String, AnnotationValue> defaultMethod : defaultValues.entrySet() ) {
+            String methodName = defaultMethod.getKey();
+            AnnotationValue defaultValue = defaultMethod.getValue();
+            AnnotationValue value = values.get( methodName );
+            switch ( methodName ) {
+                case "mySimpleEnumWithDefault":
+                    builder.setMysimpleenumwithdefault( GemValue.createEnum( value, defaultValue, MySimpleEnumGem.class ) );
+                    break;
+                case "mySimpleEnumArrayWithDefault":
+                    builder.setMysimpleenumarraywithdefault( GemValue.createEnumArray( value, defaultValue, MySimpleEnumGem.class ) );
+                    break;
+                case "mySimpleEnum":
+                    builder.setMysimpleenum( GemValue.createEnum( value, defaultValue, MySimpleEnumGem.class ) );
+                    break;
+                case "mySimpleEnumArray":
+                    builder.setMysimpleenumarray( GemValue.createEnumArray( value, defaultValue, MySimpleEnumGem.class ) );
+                    break;
+            }
+        }
+        builder.setMirror( mirror );
+        return builder.build();
+    }
+
+    /**
+     * A builder that can be implemented by the user to define custom logic e.g. in the
+     * build method, prior to creating the annotation gem.
+     */
+    public interface Builder<T> {
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationPackageGem#mySimpleEnumWithDefault}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationPackageGem}
+        */
+        Builder<T> setMysimpleenumwithdefault(GemValue<MySimpleEnumGem> methodName );
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationPackageGem#mySimpleEnumArrayWithDefault}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationPackageGem}
+        */
+        Builder<T> setMysimpleenumarraywithdefault(GemValue<List<MySimpleEnumGem>> methodName );
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationPackageGem#mySimpleEnum}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationPackageGem}
+        */
+        Builder<T> setMysimpleenum(GemValue<MySimpleEnumGem> methodName );
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationPackageGem#mySimpleEnumArray}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationPackageGem}
+        */
+        Builder<T> setMysimpleenumarray(GemValue<List<MySimpleEnumGem>> methodName );
+
+        /**
+         * Sets the annotation mirror
+         *
+         * @param mirror the mirror which this gem represents
+         *
+         * @return the {@link Builder} for this gem, representing {@link EnumAnnotationPackageGem}
+         */
+          Builder<T> setMirror( AnnotationMirror mirror );
+
+        /**
+         * The build method can be overriden in a custom custom implementation, which allows
+         * the user to define his own custom validation on the annotation.
+         *
+         * @return the representation of the annotation
+         */
+        T build();
+    }
+
+    private static class BuilderImpl implements Builder<EnumAnnotationPackageGem> {
+
+        private GemValue<MySimpleEnumGem> mySimpleEnumWithDefault;
+        private GemValue<List<MySimpleEnumGem>> mySimpleEnumArrayWithDefault;
+        private GemValue<MySimpleEnumGem> mySimpleEnum;
+        private GemValue<List<MySimpleEnumGem>> mySimpleEnumArray;
+        private AnnotationMirror mirror;
+
+        public Builder<EnumAnnotationPackageGem> setMysimpleenumwithdefault(GemValue<MySimpleEnumGem> mySimpleEnumWithDefault ) {
+            this.mySimpleEnumWithDefault = mySimpleEnumWithDefault;
+            return this;
+        }
+
+        public Builder<EnumAnnotationPackageGem> setMysimpleenumarraywithdefault(GemValue<List<MySimpleEnumGem>> mySimpleEnumArrayWithDefault ) {
+            this.mySimpleEnumArrayWithDefault = mySimpleEnumArrayWithDefault;
+            return this;
+        }
+
+        public Builder<EnumAnnotationPackageGem> setMysimpleenum(GemValue<MySimpleEnumGem> mySimpleEnum ) {
+            this.mySimpleEnum = mySimpleEnum;
+            return this;
+        }
+
+        public Builder<EnumAnnotationPackageGem> setMysimpleenumarray(GemValue<List<MySimpleEnumGem>> mySimpleEnumArray ) {
+            this.mySimpleEnumArray = mySimpleEnumArray;
+            return this;
+        }
+
+        public Builder<EnumAnnotationPackageGem> setMirror( AnnotationMirror mirror ) {
+            this.mirror = mirror;
+            return this;
+        }
+
+        public EnumAnnotationPackageGem build() {
+            return new EnumAnnotationPackageGem( this );
+        }
+    }
+
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/EnumAnnotationRegisterGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/EnumAnnotationRegisterGem.java
@@ -1,0 +1,231 @@
+package org.mapstruct.tools.gem.processor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import org.mapstruct.tools.gem.Gem;
+import org.mapstruct.tools.gem.GemValue;
+
+
+public class EnumAnnotationRegisterGem implements Gem {
+
+    private final GemValue<MySimpleEnumGem> mySimpleEnumWithDefault;
+    private final GemValue<List<MySimpleEnumGem>> mySimpleEnumArrayWithDefault;
+    private final GemValue<MySimpleEnumGem> mySimpleEnum;
+    private final GemValue<List<MySimpleEnumGem>> mySimpleEnumArray;
+    private final boolean isValid;
+    private final AnnotationMirror mirror;
+
+    private EnumAnnotationRegisterGem( BuilderImpl builder ) {
+        this.mySimpleEnumWithDefault = builder.mySimpleEnumWithDefault;
+        this.mySimpleEnumArrayWithDefault = builder.mySimpleEnumArrayWithDefault;
+        this.mySimpleEnum = builder.mySimpleEnum;
+        this.mySimpleEnumArray = builder.mySimpleEnumArray;
+        isValid = ( this.mySimpleEnumWithDefault != null && this.mySimpleEnumWithDefault.isValid() )
+               && ( this.mySimpleEnumArrayWithDefault != null && this.mySimpleEnumArrayWithDefault.isValid() )
+               && ( this.mySimpleEnum != null && this.mySimpleEnum.isValid() )
+               && ( this.mySimpleEnumArray != null && this.mySimpleEnumArray.isValid() );
+        mirror = builder.mirror;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationRegisterGem#mySimpleEnumWithDefault}
+    */
+    public GemValue<MySimpleEnumGem> mySimpleEnumWithDefault( ) {
+        return mySimpleEnumWithDefault;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationRegisterGem#mySimpleEnumArrayWithDefault}
+    */
+    public GemValue<List<MySimpleEnumGem>> mySimpleEnumArrayWithDefault( ) {
+        return mySimpleEnumArrayWithDefault;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationRegisterGem#mySimpleEnum}
+    */
+    public GemValue<MySimpleEnumGem> mySimpleEnum( ) {
+        return mySimpleEnum;
+    }
+
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link EnumAnnotationRegisterGem#mySimpleEnumArray}
+    */
+    public GemValue<List<MySimpleEnumGem>> mySimpleEnumArray( ) {
+        return mySimpleEnumArray;
+    }
+
+    @Override
+    public AnnotationMirror mirror( ) {
+        return mirror;
+    }
+
+    @Override
+    public boolean isValid( ) {
+        return isValid;
+    }
+
+    public static EnumAnnotationRegisterGem  instanceOn(Element element) {
+        return build( element, new BuilderImpl() );
+    }
+
+    public static EnumAnnotationRegisterGem instanceOn(AnnotationMirror mirror ) {
+        return build( mirror, new BuilderImpl() );
+    }
+
+    public static  <T> T  build(Element element, Builder<T> builder) {
+        AnnotationMirror mirror = element.getAnnotationMirrors().stream()
+            .filter( a ->  "org.mapstruct.tools.gem.test.enummapping.EnumAnnotation".contentEquals( ( ( TypeElement )a.getAnnotationType().asElement() ).getQualifiedName() ) )
+            .findAny()
+            .orElse( null );
+        return build( mirror, builder );
+    }
+
+    public static <T> T build(AnnotationMirror mirror, Builder<T> builder ) {
+
+        // return fast
+        if ( mirror == null || builder == null ) {
+            return null;
+        }
+
+        // fetch defaults from all defined values in the annotation type
+        List<ExecutableElement> enclosed = ElementFilter.methodsIn( mirror.getAnnotationType().asElement().getEnclosedElements() );
+        Map<String, AnnotationValue> defaultValues = new HashMap<>( enclosed.size() );
+        enclosed.forEach( e -> defaultValues.put( e.getSimpleName().toString(), e.getDefaultValue() ) );
+
+        // fetch all explicitely set annotation values in the annotation instance
+        Map<String, AnnotationValue> values = new HashMap<>( enclosed.size() );
+        mirror.getElementValues().forEach( (key, value) -> values.put( key.getSimpleName().toString(), value ) );
+
+        // iterate and populate builder
+        for ( Map.Entry<String, AnnotationValue> defaultMethod : defaultValues.entrySet() ) {
+            String methodName = defaultMethod.getKey();
+            AnnotationValue defaultValue = defaultMethod.getValue();
+            AnnotationValue value = values.get( methodName );
+            switch ( methodName ) {
+                case "mySimpleEnumWithDefault":
+                    builder.setMysimpleenumwithdefault( GemValue.createEnum( value, defaultValue, MySimpleEnumGem.class ) );
+                    break;
+                case "mySimpleEnumArrayWithDefault":
+                    builder.setMysimpleenumarraywithdefault( GemValue.createEnumArray( value, defaultValue, MySimpleEnumGem.class ) );
+                    break;
+                case "mySimpleEnum":
+                    builder.setMysimpleenum( GemValue.createEnum( value, defaultValue, MySimpleEnumGem.class ) );
+                    break;
+                case "mySimpleEnumArray":
+                    builder.setMysimpleenumarray( GemValue.createEnumArray( value, defaultValue, MySimpleEnumGem.class ) );
+                    break;
+            }
+        }
+        builder.setMirror( mirror );
+        return builder.build();
+    }
+
+    /**
+     * A builder that can be implemented by the user to define custom logic e.g. in the
+     * build method, prior to creating the annotation gem.
+     */
+    public interface Builder<T> {
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationRegisterGem#mySimpleEnumWithDefault}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationRegisterGem}
+        */
+        Builder<T> setMysimpleenumwithdefault(GemValue<MySimpleEnumGem> methodName );
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationRegisterGem#mySimpleEnumArrayWithDefault}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationRegisterGem}
+        */
+        Builder<T> setMysimpleenumarraywithdefault(GemValue<List<MySimpleEnumGem>> methodName );
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationRegisterGem#mySimpleEnum}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationRegisterGem}
+        */
+        Builder<T> setMysimpleenum(GemValue<MySimpleEnumGem> methodName );
+
+       /**
+        * Sets the {@link GemValue} for {@link EnumAnnotationRegisterGem#mySimpleEnumArray}
+        *
+        * @return the {@link Builder} for this gem, representing {@link EnumAnnotationRegisterGem}
+        */
+        Builder<T> setMysimpleenumarray(GemValue<List<MySimpleEnumGem>> methodName );
+
+        /**
+         * Sets the annotation mirror
+         *
+         * @param mirror the mirror which this gem represents
+         *
+         * @return the {@link Builder} for this gem, representing {@link EnumAnnotationRegisterGem}
+         */
+          Builder<T> setMirror( AnnotationMirror mirror );
+
+        /**
+         * The build method can be overriden in a custom custom implementation, which allows
+         * the user to define his own custom validation on the annotation.
+         *
+         * @return the representation of the annotation
+         */
+        T build();
+    }
+
+    private static class BuilderImpl implements Builder<EnumAnnotationRegisterGem> {
+
+        private GemValue<MySimpleEnumGem> mySimpleEnumWithDefault;
+        private GemValue<List<MySimpleEnumGem>> mySimpleEnumArrayWithDefault;
+        private GemValue<MySimpleEnumGem> mySimpleEnum;
+        private GemValue<List<MySimpleEnumGem>> mySimpleEnumArray;
+        private AnnotationMirror mirror;
+
+        public Builder<EnumAnnotationRegisterGem> setMysimpleenumwithdefault(GemValue<MySimpleEnumGem> mySimpleEnumWithDefault ) {
+            this.mySimpleEnumWithDefault = mySimpleEnumWithDefault;
+            return this;
+        }
+
+        public Builder<EnumAnnotationRegisterGem> setMysimpleenumarraywithdefault(GemValue<List<MySimpleEnumGem>> mySimpleEnumArrayWithDefault ) {
+            this.mySimpleEnumArrayWithDefault = mySimpleEnumArrayWithDefault;
+            return this;
+        }
+
+        public Builder<EnumAnnotationRegisterGem> setMysimpleenum(GemValue<MySimpleEnumGem> mySimpleEnum ) {
+            this.mySimpleEnum = mySimpleEnum;
+            return this;
+        }
+
+        public Builder<EnumAnnotationRegisterGem> setMysimpleenumarray(GemValue<List<MySimpleEnumGem>> mySimpleEnumArray ) {
+            this.mySimpleEnumArray = mySimpleEnumArray;
+            return this;
+        }
+
+        public Builder<EnumAnnotationRegisterGem> setMirror( AnnotationMirror mirror ) {
+            this.mirror = mirror;
+            return this;
+        }
+
+        public EnumAnnotationRegisterGem build() {
+            return new EnumAnnotationRegisterGem( this );
+        }
+    }
+
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SimpleEnumGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SimpleEnumGem.java
@@ -1,0 +1,10 @@
+package org.mapstruct.tools.gem.processor;
+
+/**
+ * Gem for the enum {@link org.mapstruct.tools.gem.test.enummapping.SimpleEnum}
+*/
+public enum SimpleEnumGem {
+    A,
+    B,
+    C
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SomeAnnotationGem.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/tools/gem/processor/SomeAnnotationGem.java
@@ -28,6 +28,7 @@ public class SomeAnnotationGem implements Gem {
     private final GemValue<Double> myDoubleWithDefault;
     private final GemValue<String> myStringWithDefault;
     private final GemValue<String> myEnumWithDefault;
+    private final GemValue<List<String>> myEnumArrayWithDefault;
     private final GemValue<TypeMirror> myClass;
     private final GemValue<Boolean> myBoolean;
     private final GemValue<Character> myChar;
@@ -39,6 +40,7 @@ public class SomeAnnotationGem implements Gem {
     private final GemValue<Double> myDouble;
     private final GemValue<String> myString;
     private final GemValue<String> myEnum;
+    private final GemValue<List<String>> myEnumArray;
     private final boolean isValid;
     private final AnnotationMirror mirror;
 
@@ -54,6 +56,7 @@ public class SomeAnnotationGem implements Gem {
         this.myDoubleWithDefault = builder.myDoubleWithDefault;
         this.myStringWithDefault = builder.myStringWithDefault;
         this.myEnumWithDefault = builder.myEnumWithDefault;
+        this.myEnumArrayWithDefault = builder.myEnumArrayWithDefault;
         this.myClass = builder.myClass;
         this.myBoolean = builder.myBoolean;
         this.myChar = builder.myChar;
@@ -65,6 +68,7 @@ public class SomeAnnotationGem implements Gem {
         this.myDouble = builder.myDouble;
         this.myString = builder.myString;
         this.myEnum = builder.myEnum;
+        this.myEnumArray = builder.myEnumArray;
         isValid = ( this.myClassWithDefault != null && this.myClassWithDefault.isValid() )
                && ( this.myBooleanWithDefault != null && this.myBooleanWithDefault.isValid() )
                && ( this.myCharWithDefault != null && this.myCharWithDefault.isValid() )
@@ -76,6 +80,7 @@ public class SomeAnnotationGem implements Gem {
                && ( this.myDoubleWithDefault != null && this.myDoubleWithDefault.isValid() )
                && ( this.myStringWithDefault != null && this.myStringWithDefault.isValid() )
                && ( this.myEnumWithDefault != null && this.myEnumWithDefault.isValid() )
+               && ( this.myEnumArrayWithDefault != null && this.myEnumArrayWithDefault.isValid() )
                && ( this.myClass != null && this.myClass.isValid() )
                && ( this.myBoolean != null && this.myBoolean.isValid() )
                && ( this.myChar != null && this.myChar.isValid() )
@@ -86,7 +91,8 @@ public class SomeAnnotationGem implements Gem {
                && ( this.myFloat != null && this.myFloat.isValid() )
                && ( this.myDouble != null && this.myDouble.isValid() )
                && ( this.myString != null && this.myString.isValid() )
-               && ( this.myEnum != null && this.myEnum.isValid() );
+               && ( this.myEnum != null && this.myEnum.isValid() )
+               && ( this.myEnumArray != null && this.myEnumArray.isValid() );
         mirror = builder.mirror;
     }
 
@@ -192,6 +198,15 @@ public class SomeAnnotationGem implements Gem {
     /**
     * accessor
     *
+    * @return the {@link GemValue} for {@link SomeAnnotationGem#myEnumArrayWithDefault}
+    */
+    public GemValue<List<String>> myEnumArrayWithDefault( ) {
+        return myEnumArrayWithDefault;
+    }
+
+    /**
+    * accessor
+    *
     * @return the {@link GemValue} for {@link SomeAnnotationGem#myClass}
     */
     public GemValue<TypeMirror> myClass( ) {
@@ -288,6 +303,15 @@ public class SomeAnnotationGem implements Gem {
         return myEnum;
     }
 
+    /**
+    * accessor
+    *
+    * @return the {@link GemValue} for {@link SomeAnnotationGem#myEnumArray}
+    */
+    public GemValue<List<String>> myEnumArray( ) {
+        return myEnumArray;
+    }
+
     @Override
     public AnnotationMirror mirror( ) {
         return mirror;
@@ -369,6 +393,9 @@ public class SomeAnnotationGem implements Gem {
                 case "myEnumWithDefault":
                     builder.setMyenumwithdefault( GemValue.createEnum( value, defaultValue ) );
                     break;
+                case "myEnumArrayWithDefault":
+                    builder.setMyenumarraywithdefault( GemValue.createEnumArray( value, defaultValue ) );
+                    break;
                 case "myClass":
                     builder.setMyclass( GemValue.create( value, defaultValue, TypeMirror.class ) );
                     break;
@@ -401,6 +428,9 @@ public class SomeAnnotationGem implements Gem {
                     break;
                 case "myEnum":
                     builder.setMyenum( GemValue.createEnum( value, defaultValue ) );
+                    break;
+                case "myEnumArray":
+                    builder.setMyenumarray( GemValue.createEnumArray( value, defaultValue ) );
                     break;
             }
         }
@@ -492,6 +522,13 @@ public class SomeAnnotationGem implements Gem {
         Builder<T> setMyenumwithdefault(GemValue<String> methodName );
 
        /**
+        * Sets the {@link GemValue} for {@link SomeAnnotationGem#myEnumArrayWithDefault}
+        *
+        * @return the {@link Builder} for this gem, representing {@link SomeAnnotationGem}
+        */
+        Builder<T> setMyenumarraywithdefault(GemValue<List<String>> methodName );
+
+       /**
         * Sets the {@link GemValue} for {@link SomeAnnotationGem#myClass}
         *
         * @return the {@link Builder} for this gem, representing {@link SomeAnnotationGem}
@@ -568,6 +605,13 @@ public class SomeAnnotationGem implements Gem {
         */
         Builder<T> setMyenum(GemValue<String> methodName );
 
+       /**
+        * Sets the {@link GemValue} for {@link SomeAnnotationGem#myEnumArray}
+        *
+        * @return the {@link Builder} for this gem, representing {@link SomeAnnotationGem}
+        */
+        Builder<T> setMyenumarray(GemValue<List<String>> methodName );
+
         /**
          * Sets the annotation mirror
          *
@@ -599,6 +643,7 @@ public class SomeAnnotationGem implements Gem {
         private GemValue<Double> myDoubleWithDefault;
         private GemValue<String> myStringWithDefault;
         private GemValue<String> myEnumWithDefault;
+        private GemValue<List<String>> myEnumArrayWithDefault;
         private GemValue<TypeMirror> myClass;
         private GemValue<Boolean> myBoolean;
         private GemValue<Character> myChar;
@@ -610,6 +655,7 @@ public class SomeAnnotationGem implements Gem {
         private GemValue<Double> myDouble;
         private GemValue<String> myString;
         private GemValue<String> myEnum;
+        private GemValue<List<String>> myEnumArray;
         private AnnotationMirror mirror;
 
         public Builder<SomeAnnotationGem> setMyclasswithdefault(GemValue<TypeMirror> myClassWithDefault ) {
@@ -667,6 +713,11 @@ public class SomeAnnotationGem implements Gem {
             return this;
         }
 
+        public Builder<SomeAnnotationGem> setMyenumarraywithdefault(GemValue<List<String>> myEnumArrayWithDefault ) {
+            this.myEnumArrayWithDefault = myEnumArrayWithDefault;
+            return this;
+        }
+
         public Builder<SomeAnnotationGem> setMyclass(GemValue<TypeMirror> myClass ) {
             this.myClass = myClass;
             return this;
@@ -719,6 +770,11 @@ public class SomeAnnotationGem implements Gem {
 
         public Builder<SomeAnnotationGem> setMyenum(GemValue<String> myEnum ) {
             this.myEnum = myEnum;
+            return this;
+        }
+
+        public Builder<SomeAnnotationGem> setMyenumarray(GemValue<List<String>> myEnumArray ) {
+            this.myEnumArray = myEnumArray;
             return this;
         }
 

--- a/test/src/main/java/org/mapstruct/tools/gem/Tester.java
+++ b/test/src/main/java/org/mapstruct/tools/gem/Tester.java
@@ -18,7 +18,8 @@ import org.mapstruct.tools.gem.test.SomeAnnotation;
     myFloat = 99.3f,
     myDouble = 5033.19d,
     myString = "some",
-    myEnum = SomeAnnotation.TEST.B
+    myEnum = SomeAnnotation.TEST.B,
+    myEnumArray = {SomeAnnotation.TEST.B}
 )
 public class Tester {
 }

--- a/test/src/main/java/org/mapstruct/tools/gem/test/SomeAnnotation.java
+++ b/test/src/main/java/org/mapstruct/tools/gem/test/SomeAnnotation.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE )
 public @interface SomeAnnotation {
 
-    enum TEST { A, B };
+    enum TEST { A, B }
 
     Class<?> myClassWithDefault() default SomeAnnotation.class;
 
@@ -43,6 +43,8 @@ public @interface SomeAnnotation {
 
     TEST myEnumWithDefault() default TEST.A;
 
+    TEST[] myEnumArrayWithDefault() default {TEST.A, TEST.B};
+
     Class<?> myClass();
 
     boolean myBoolean();
@@ -64,5 +66,7 @@ public @interface SomeAnnotation {
     String myString();
 
     TEST myEnum();
+
+    TEST[] myEnumArray();
 
 }

--- a/test/src/main/java/org/mapstruct/tools/gem/test/enummapping/EnumAnnotation.java
+++ b/test/src/main/java/org/mapstruct/tools/gem/test/enummapping/EnumAnnotation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.tools.gem.test.enummapping;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE )
+public @interface EnumAnnotation {
+    SimpleEnum mySimpleEnumWithDefault() default SimpleEnum.C;
+    SimpleEnum[] mySimpleEnumArrayWithDefault() default {SimpleEnum.A, SimpleEnum.B};
+    SimpleEnum mySimpleEnum();
+    SimpleEnum[] mySimpleEnumArray();
+}

--- a/test/src/main/java/org/mapstruct/tools/gem/test/enummapping/SimpleEnum.java
+++ b/test/src/main/java/org/mapstruct/tools/gem/test/enummapping/SimpleEnum.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.tools.gem.test.enummapping;
+
+public enum SimpleEnum {
+    A,B,C
+}


### PR DESCRIPTION
This PR introduces support for Java enums.
When an `enum` is used as a `@GemDefinition` value, a corresponding enum `Gem` is generated automatically. Additionally, other generated gems will reference the generated enum gem whenever applicable.

For cases where a custom enum implementation is required, it can be registered using `@RegisterGem`. In this scenario, the plugin validates that the enum constants of the custom implementation match those of the original enum, ensuring consistency between both definitions.

To avoid ambiguity, multiple registrations or generations for the same enum are not allowed.

@filiphr could you take a look?